### PR TITLE
Implement CLI subcommands with logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +204,18 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -714,6 +741,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1067,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "object"
@@ -2288,6 +2348,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +2525,7 @@ name = "xserver-auto-renew-rs"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "chrono",
  "clap",
  "cookie_store",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ tokio = { version = "1.46.1", features = ["full"] }
 ua_generator = "0.5.17"
 url = "2.5.4"
 bincode = "2.0.1"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }

--- a/src/data.rs
+++ b/src/data.rs
@@ -37,6 +37,9 @@ pub static DATA: LazyLock<Mutex<OptionData>> = LazyLock::new(|| {
 
 impl OptionData {
     fn save(&self) {
+        if let Some(parent) = std::path::Path::new(SAVE_PATH).parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
         if let Some(ref data) = self.0 {
             let mut writer = Vec::new();
             bincode::encode_into_std_write(data, &mut writer, CONF).expect("Failed to encode data");

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,33 @@
+use std::fs::{OpenOptions, read_to_string};
+use std::io::Write;
+use chrono::{DateTime, Local};
+
+const LOG_PATH: &str = "data/run.log";
+
+pub fn log_message(msg: &str) {
+    let now: DateTime<Local> = Local::now();
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(LOG_PATH)
+        .expect("Failed to open log file");
+    writeln!(file, "{} {}", now.to_rfc3339(), msg).expect("Failed to write log");
+}
+
+pub fn read_logs() -> Vec<(DateTime<Local>, String)> {
+    if let Ok(content) = read_to_string(LOG_PATH) {
+        content
+            .lines()
+            .filter_map(|line| {
+                let mut parts = line.splitn(2, ' ');
+                let ts = parts.next()?;
+                let msg = parts.next()?.to_string();
+                DateTime::parse_from_rfc3339(ts)
+                    .ok()
+                    .map(|dt| (dt.with_timezone(&Local), msg))
+            })
+            .collect()
+    } else {
+        Vec::new()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
+use clap::{Parser, Subcommand};
+
 use crate::{
     data::DATA,
     login::LoginStatus,
-    server::{ExtendResponse, get_server_id},
+    server::{get_server_id, ExtendResponse},
 };
 
 mod account;
@@ -10,53 +12,114 @@ mod data;
 mod form;
 mod login;
 mod server;
+mod logger;
+
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Interactive login and extend VPS
+    Login,
+    /// Extend VPS without interaction
+    Extend,
+    /// Show stored account and run logs
+    Status,
+}
 
 #[tokio::main]
 async fn main() {
-    let client = {
-        let mut data = DATA.lock().expect("Failed to lock data");
-        if !data.is_some() {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Login => login_flow().await,
+        Commands::Extend => extend_flow().await,
+        Commands::Status => {
+            show_status();
+            return;
+        }
+    }
+}
+
+async fn create_client() -> client::Client {
+    let data = DATA.lock().expect("lock data");
+    let data = data.unwrap();
+    client::create_client(data.get_ua(), data.get_cookie())
+}
+
+async fn login_flow() {
+    // handle account input/update
+    {
+        let mut data = DATA.lock().expect("lock data");
+        if data.is_some() {
+            let email = data.unwrap().get_account().email.clone();
+            println!("Current account: {}", email);
+            println!("Update credentials? (y/N)");
+            let mut buf = String::new();
+            std::io::stdin().read_line(&mut buf).unwrap();
+            if buf.trim().eq_ignore_ascii_case("y") {
+                buf.clear();
+                println!("Please enter your email:");
+                std::io::stdin().read_line(&mut buf).unwrap();
+                let email = buf.trim().to_string();
+                buf.clear();
+                println!("Please enter your password:");
+                std::io::stdin().read_line(&mut buf).unwrap();
+                let password = buf.trim().to_string();
+                let acc = account::Account { email, password };
+                data.save_account(acc);
+            }
+        } else {
             let mut buf = String::new();
             println!("Please enter your email:");
-            std::io::stdin()
-                .read_line(&mut buf)
-                .expect("Failed to read email");
+            std::io::stdin().read_line(&mut buf).unwrap();
             let email = buf.trim().to_string();
             buf.clear();
             println!("Please enter your password:");
-            std::io::stdin()
-                .read_line(&mut buf)
-                .expect("Failed to read password");
+            std::io::stdin().read_line(&mut buf).unwrap();
             let password = buf.trim().to_string();
-            let account = account::Account { email, password };
-            data.save_account(account);
+            let acc = account::Account { email, password };
+            data.save_account(acc);
         }
-        let data = data.unwrap();
-        client::create_client(data.get_ua(), data.get_cookie())
-    };
+    }
 
-    let form = client.login_page().await.unwrap();
+    let client = create_client().await;
+    if let Err(e) = do_login_and_extend(&client, true).await {
+        logger::log_message(&format!("FAILURE {}", e));
+    }
+}
 
-    let res = client
-        .try_login(
-            &form,
-            DATA.lock()
-                .expect("Failed to lock data")
-                .unwrap()
-                .get_account(),
-        )
+async fn extend_flow() {
+    let client = create_client().await;
+    if let Err(e) = do_login_and_extend(&client, false).await {
+        logger::log_message(&format!("FAILURE {}", e));
+    }
+}
+
+async fn do_login_and_extend(client: &client::Client, interactive: bool) -> Result<(), String> {
+    let form = client
+        .login_page()
         .await
-        .unwrap();
-
-    let html = match res {
-        LoginStatus::Success(text) => {
-            println!("Login successful!");
-            text
-        }
-        LoginStatus::Failure(msg) => {
-            panic!("{:?}", msg);
-        }
+        .map_err(|e| format!("login page: {}", e))?;
+    let account = {
+        let data = DATA.lock().unwrap();
+        data.unwrap().get_account().clone()
+    };
+    let mut login_res = client
+        .try_login(&form, &account)
+        .await
+        .map_err(|e| format!("login: {}", e))?;
+    let mut html = String::new();
+    match login_res {
+        LoginStatus::Success(text) => html = text,
+        LoginStatus::Failure(msg) => return Err(msg),
         LoginStatus::TowWayAuthRequired(form, email) => {
+            if !interactive {
+                return Err("Two-way authentication required".into());
+            }
             if let Some(email) = email {
                 println!("Two-way authentication required. Email: {}", email);
             } else {
@@ -65,52 +128,64 @@ async fn main() {
             let form = client
                 .two_way_select_email(&form)
                 .await
-                .expect("Failed to select email for two-way authentication");
+                .map_err(|e| format!("auth select: {}", e))?;
             let code = {
                 let mut buf = String::new();
                 println!("Please enter the authentication code sent to your email:");
-                std::io::stdin()
-                    .read_line(&mut buf)
-                    .expect("Failed to read authentication code");
+                std::io::stdin().read_line(&mut buf).unwrap();
                 buf.trim().to_string()
             };
-            let res = client
+            match client
                 .two_way_auth(&form, &code)
                 .await
-                .expect("Failed to complete two-way authentication");
-            if let LoginStatus::Success(text) = res {
-                println!("Login successful!");
-                text
-            } else {
-                panic!("Two-way authentication failed.");
+                .map_err(|e| format!("two-way auth: {}", e))? {
+                LoginStatus::Success(text) => {
+                    html = text;
+                }
+                _ => return Err("Two-way authentication failed".into()),
             }
         }
-    };
+    }
 
     {
         let cookie = client.get_cookie();
-        let mut data = DATA.lock().expect("Failed to lock data");
+        let mut data = DATA.lock().unwrap();
         data.save_cookie(cookie);
     }
 
-    let vps = get_server_id(html.as_str());
-    println!("VPS: {:?}", vps);
-
-    if let Some(id) = vps {
-        let extend_res = client.extend_vps(&id).await.expect("Failed to extend VPS");
-        let res = client
-            .submit_extend_form(&extend_res)
-            .await
-            .expect("Failed to submit extend form");
-        match res {
-            ExtendResponse::Success(msg) => {
-                println!("Extend successful: {}", msg);
-            }
-            ExtendResponse::Failure(msg) => {
-                println!("Extend failed: {}", msg);
-            }
+    let vps = get_server_id(&html).ok_or_else(|| "No VPS found".to_string())?;
+    let extend_form = client
+        .extend_vps(&vps)
+        .await
+        .map_err(|e| format!("extend vps: {}", e))?;
+    match client
+        .submit_extend_form(&extend_form)
+        .await
+        .map_err(|e| format!("submit extend: {}", e))? {
+        ExtendResponse::Success(msg) => {
+            println!("Extend successful: {}", msg);
+            logger::log_message(&format!("SUCCESS {}", msg));
+            Ok(())
         }
+        ExtendResponse::Failure(msg) => {
+            println!("Extend failed: {}", msg);
+            Err(msg)
+        }
+    }
+}
+
+fn show_status() {
+    let data = DATA.lock().unwrap();
+    if data.is_some() {
+        println!("Account: {}", data.unwrap().get_account().email);
     } else {
-        println!("No VPS found.");
+        println!("No account configured");
+    }
+    let logs = logger::read_logs();
+    if let Some((ts, msg)) = logs.last() {
+        println!("Last run: {} - {}", ts.format("%Y-%m-%d %H:%M:%S"), msg);
+    }
+    if let Some((ts, _)) = logs.iter().rev().find(|(_, m)| m.starts_with("SUCCESS")) {
+        println!("Last success: {}", ts.format("%Y-%m-%d %H:%M:%S"));
     }
 }


### PR DESCRIPTION
## Summary
- introduce `chrono` for timestamped log entries
- add a `logger` module storing logs beside `data.bin`
- create `data` directory as needed when saving
- replace old main logic with clap-based `login`, `extend`, and `status` commands

## Testing
- `cargo build --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68735aec9efc832c9844699185ed8e13