### PR TITLE
Add systemd auto renewal commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,10 @@ enum Commands {
     Extend,
     /// Show stored account and run logs
     Status,
+    /// Enable daily automatic extension
+    Enable,
+    /// Disable automatic extension
+    Disable,
 }
 
 #[tokio::main]
@@ -41,6 +45,8 @@ async fn main() {
             show_status();
             return;
         }
+        Commands::Enable => enable_auto(),
+        Commands::Disable => disable_auto(),
     }
 }
 
@@ -190,4 +196,49 @@ fn show_status() {
     if let Some((ts, _)) = logs.iter().rev().find(|(_, m)| m.starts_with("SUCCESS")) {
         println!("Last success: {}", ts.format("%Y-%m-%d %H:%M:%S"));
     }
+}
+
+fn enable_auto() {
+    {
+        let data = DATA.lock().unwrap();
+        if !data.is_some() {
+            println!("No account configured. Run 'xrenew login' first.");
+            return;
+        }
+    }
+
+    let exe = std::env::current_exe().expect("get exe path");
+    let service = include_str!("../systemd/xrenew.service")
+        .replace("{{EXEC_PATH}}", exe.to_str().expect("exe path to str"));
+    let timer = include_str!("../systemd/xrenew.timer");
+    let dir = directories::BaseDirs::new()
+        .expect("get base dirs")
+        .config_dir()
+        .join("systemd/user");
+    std::fs::create_dir_all(&dir).expect("create systemd dir");
+    std::fs::write(dir.join("xrenew.service"), service).expect("write service");
+    std::fs::write(dir.join("xrenew.timer"), timer).expect("write timer");
+    let _ = std::process::Command::new("systemctl")
+        .args(["--user", "daemon-reload"])
+        .status();
+    let _ = std::process::Command::new("systemctl")
+        .args(["--user", "enable", "--now", "xrenew.timer"])
+        .status();
+    println!("Automatic extension enabled");
+}
+
+fn disable_auto() {
+    let dir = directories::BaseDirs::new()
+        .expect("get base dirs")
+        .config_dir()
+        .join("systemd/user");
+    let _ = std::process::Command::new("systemctl")
+        .args(["--user", "disable", "--now", "xrenew.timer"])
+        .status();
+    let _ = std::process::Command::new("systemctl")
+        .args(["--user", "stop", "xrenew.timer"])
+        .status();
+    std::fs::remove_file(dir.join("xrenew.service")).ok();
+    std::fs::remove_file(dir.join("xrenew.timer")).ok();
+    println!("Automatic extension disabled");
 }

--- a/systemd/xrenew.service
+++ b/systemd/xrenew.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Xserver VPS auto extension
+
+[Service]
+Type=oneshot
+ExecStart={{EXEC_PATH}} extend

--- a/systemd/xrenew.timer
+++ b/systemd/xrenew.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Xserver VPS auto extension timer
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- enable daily auto renewal and disable with systemd timer
- embed systemd service templates

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68736a4cf97c832ca65890cbf4501c61