### PR TITLE
Add webhook notifications and timed auto renew

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,6 +2581,7 @@ dependencies = [
  "reqwest_cookie_store",
  "scraper",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "ua_generator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ reqwest = { version = "0.12.22", features = ["json", "cookies", "rustls-tls"] }
 reqwest_cookie_store = "0.8.0"
 scraper = "0.23.1"
 serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0"
 thiserror = "2.0.12"
 tokio = { version = "1.46.1", features = ["full"] }
 ua_generator = "0.5.17"

--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ curl -sSf https://raw.githubusercontent.com/h-sumiya/xserver-auto-renew-rs/main/
 2. `xrenew extend`
    - 手動で延長処理を行います。保存済みの認証情報を利用して自動でログインします。
 3. `xrenew enable`
-   - systemd タイマーを登録し、毎日自動で延長処理を行います。
-4. `xrenew disable`
+   - systemd タイマーを登録し、12時間おきに自動で延長処理を試みます。
+4. `xrenew webhook <URL>`
+   - 実行結果を Discord へ通知する Webhook URL を設定します。
+5. `xrenew disable`
    - 上記タイマーを無効化します。
-5. `xrenew status`
-   - 保存されているアカウント情報と実行ログを表示します。
+6. `xrenew status`
+   - 保存されているアカウント情報と実行ログ、Webhook設定、タイマー状態を表示します。
 
 > [!IMPORTANT]
 > 初回実行時に二段階認証が求められる場合があります。

--- a/src/data.rs
+++ b/src/data.rs
@@ -18,6 +18,7 @@ pub struct Data {
     account: Account,
     ua: String,
     cookie: Option<String>,
+    webhook: Option<String>,
 }
 
 const CONF: Configuration = standard();
@@ -61,10 +62,12 @@ impl OptionData {
     }
 
     pub fn save_account(&mut self, account: Account) {
+        let webhook = self.0.as_ref().and_then(|d| d.webhook.clone());
         self.0 = Some(Data {
             account,
             ua: spoof_ua().to_string(),
             cookie: None,
+            webhook,
         });
         self.save();
     }
@@ -74,6 +77,16 @@ impl OptionData {
             data.cookie = Some(cookie);
         } else {
             panic!("No data to save cookie to");
+        }
+        self.save();
+    }
+
+    pub fn save_webhook(&mut self, url: Option<String>) {
+        if let Some(ref mut data) = self.0 {
+            data.webhook = url;
+        } else {
+            println!("No account configured. Run 'xrenew login' first.");
+            return;
         }
         self.save();
     }
@@ -98,5 +111,9 @@ impl Data {
 
     pub fn get_cookie(&self) -> Option<String> {
         self.cookie.clone()
+    }
+
+    pub fn get_webhook(&self) -> Option<String> {
+        self.webhook.clone()
     }
 }

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -1,0 +1,21 @@
+use crate::data::DATA;
+use serde_json::json;
+
+pub async fn send(content: &str) {
+    let url = {
+        let data = DATA.lock().unwrap();
+        if data.is_some() {
+            data.unwrap().get_webhook()
+        } else {
+            None
+        }
+    };
+    if let Some(url) = url {
+        let client = reqwest::Client::new();
+        let _ = client
+            .post(&url)
+            .json(&json!({"content": content}))
+            .send()
+            .await;
+    }
+}

--- a/systemd/xrenew.service
+++ b/systemd/xrenew.service
@@ -3,4 +3,4 @@ Description=Xserver VPS auto extension
 
 [Service]
 Type=oneshot
-ExecStart={{EXEC_PATH}} extend
+ExecStart={{EXEC_PATH}} extend --auto

--- a/systemd/xrenew.timer
+++ b/systemd/xrenew.timer
@@ -2,7 +2,7 @@
 Description=Xserver VPS auto extension timer
 
 [Timer]
-OnCalendar=daily
+OnCalendar=*-*-* 00,12:00:00
 Persistent=true
 
 [Install]


### PR DESCRIPTION
## Summary
- allow setting Discord webhook via new `webhook` command
- notify webhook on success/failure and when skipped
- show webhook status and timer state in `status`
- run auto renew check every 12h via systemd timer
- skip renew if last success < 23h

## Testing
- `cargo fmt --all`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6873ba291ed4832ca67c03587856514e