### PR TITLE
Implement self-update and adjust timer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,6 +1685,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,6 +2586,7 @@ dependencies = [
  "reqwest",
  "reqwest_cookie_store",
  "scraper",
+ "semver",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ tokio = { version = "1.46.1", features = ["full"] }
 ua_generator = "0.5.17"
 url = "2.5.4"
 directories = "6.0.0"
+semver = "1.0"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ curl -sSf https://raw.githubusercontent.com/h-sumiya/xserver-auto-renew-rs/main/
    - 上記タイマーを無効化します。
 6. `xrenew status`
    - 保存されているアカウント情報と実行ログ、Webhook設定、タイマー状態を表示します。
+7. `xrenew update`
+   - 最新バージョンが公開されている場合自動でアップデートします。
 
 > [!IMPORTANT]
 > 初回実行時に二段階認証が求められる場合があります。

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,12 @@ enum Commands {
     Disable,
     /// Set Discord webhook URL
     Webhook { url: String },
+    /// Update xrenew to the latest version
+    Update {
+        /// Run from systemd timer
+        #[arg(long)]
+        auto: bool,
+    },
 }
 
 #[tokio::main]
@@ -57,6 +63,7 @@ async fn main() {
         Commands::Enable => enable_auto(),
         Commands::Disable => disable_auto(),
         Commands::Webhook { url } => set_webhook(url),
+        Commands::Update { auto } => update(auto).await,
     }
 }
 
@@ -325,5 +332,56 @@ fn should_run() -> bool {
         diff.num_hours() >= 23
     } else {
         true
+    }
+}
+
+async fn update(auto: bool) {
+    let current = semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
+    let client = reqwest::Client::new();
+    let res = client
+        .get("https://api.github.com/repos/h-sumiya/xserver-auto-renew-rs/releases/latest")
+        .header(reqwest::header::USER_AGENT, "xrenew")
+        .send()
+        .await;
+    let Ok(resp) = res else {
+        if !auto {
+            eprintln!("Failed to check latest version");
+        }
+        return;
+    };
+    let json: serde_json::Value = match resp.json().await {
+        Ok(j) => j,
+        Err(e) => {
+            if !auto {
+                eprintln!("Failed to parse version info: {}", e);
+            }
+            return;
+        }
+    };
+    let tag = json.get("tag_name").and_then(|v| v.as_str());
+    let Some(tag) = tag else { return; };
+    let latest_str = tag.trim_start_matches('v');
+    let Ok(latest) = semver::Version::parse(latest_str) else { return; };
+    if latest > current {
+        if !auto {
+            println!("Updating from {} to {}", current, latest);
+        }
+        let cmd = format!(
+            "curl -sSf https://raw.githubusercontent.com/h-sumiya/xserver-auto-renew-rs/main/install.sh | VERSION={} bash",
+            tag
+        );
+        let status = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(cmd)
+            .status();
+        if status.map(|s| s.success()).unwrap_or(false) {
+            if !auto {
+                println!("Update complete");
+            }
+        } else if !auto {
+            eprintln!("Update failed");
+        }
+    } else if !auto {
+        println!("xrenew is up to date ({}).", current);
     }
 }

--- a/systemd/xrenew.service
+++ b/systemd/xrenew.service
@@ -3,4 +3,5 @@ Description=Xserver VPS auto extension
 
 [Service]
 Type=oneshot
+ExecStartPre={{EXEC_PATH}} update --auto
 ExecStart={{EXEC_PATH}} extend --auto

--- a/systemd/xrenew.timer
+++ b/systemd/xrenew.timer
@@ -2,7 +2,7 @@
 Description=Xserver VPS auto extension timer
 
 [Timer]
-OnCalendar=*-*-* 00,12:00:00
+OnCalendar=*-*-* 00/12:10:00
 Persistent=true
 
 [Install]


### PR DESCRIPTION
## Summary
- add `update` subcommand to download the latest release when available
- run update before automatic extension via systemd
- delay the timer by 10 minutes
- document the update command

## Testing
- `cargo build --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6876002f817c832c9f75d8a794612876