### PR TITLE
Refactor main to smaller modules

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,36 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(author, version, about)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Interactive login and extend VPS
+    Login,
+    /// Extend VPS without interaction
+    Extend {
+        /// Run from systemd timer
+        #[arg(long)]
+        auto: bool,
+    },
+    /// Show stored account and run logs
+    Status,
+    /// Enable daily automatic extension
+    Enable,
+    /// Disable automatic extension
+    Disable,
+    /// Delete saved data
+    Clear,
+    /// Set Discord webhook URL
+    Webhook { url: String },
+    /// Update xrenew to the latest version
+    Update {
+        /// Run from systemd timer
+        #[arg(long)]
+        auto: bool,
+    },
+}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,0 +1,50 @@
+use crate::{data::DATA, logger};
+
+pub fn show_status() {
+    let data = DATA.lock().unwrap();
+    if data.is_some() {
+        let d = data.unwrap();
+        println!("Account: {}", d.get_account().email);
+        if d.get_webhook().is_some() {
+            println!("Webhook: set");
+        }
+    } else {
+        println!("No account configured");
+    }
+    let timer_enabled = std::process::Command::new("systemctl")
+        .args(["--user", "is-enabled", "xrenew.timer"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    println!(
+        "Auto update: {}",
+        if timer_enabled { "enabled" } else { "disabled" }
+    );
+    let logs = logger::read_logs();
+    if let Some((ts, msg)) = logs.last() {
+        println!("Last run: {} - {}", ts.format("%Y-%m-%d %H:%M:%S"), msg);
+    }
+    if let Some((ts, _)) = logs.iter().rev().find(|(_, m)| m.starts_with("SUCCESS")) {
+        println!("Last success: {}", ts.format("%Y-%m-%d %H:%M:%S"));
+    }
+}
+
+pub fn clear_data() {
+    let mut data = DATA.lock().unwrap();
+    if data.is_some() {
+        data.clear();
+        println!("Saved data deleted");
+    } else {
+        println!("No saved data");
+    }
+}
+
+pub fn set_webhook(url: String) {
+    let mut data = DATA.lock().unwrap();
+    if data.is_some() {
+        data.save_webhook(Some(url));
+        println!("Webhook set");
+    } else {
+        println!("No account configured. Run 'xrenew login' first.");
+    }
+}

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,59 @@
+use crate::data::DATA;
+
+pub fn enable_auto() {
+    {
+        let data = DATA.lock().unwrap();
+        if !data.is_some() {
+            println!("No account configured. Run 'xrenew login' first.");
+            return;
+        }
+    }
+
+    let exe = std::env::current_exe().expect("get exe path");
+    let service = include_str!("../systemd/xrenew.service")
+        .replace("{{EXEC_PATH}}", exe.to_str().expect("exe path to str"));
+    let timer = include_str!("../systemd/xrenew.timer");
+    let dir = directories::BaseDirs::new()
+        .expect("get base dirs")
+        .config_dir()
+        .join("systemd/user");
+    std::fs::create_dir_all(&dir).expect("create systemd dir");
+    std::fs::write(dir.join("xrenew.service"), service).expect("write service");
+    std::fs::write(dir.join("xrenew.timer"), timer).expect("write timer");
+    let _ = std::process::Command::new("systemctl")
+        .args(["--user", "daemon-reload"])
+        .status();
+    let _ = std::process::Command::new("systemctl")
+        .args(["--user", "enable", "--now", "xrenew.timer"])
+        .status();
+    println!("Automatic extension enabled");
+}
+
+pub fn disable_auto() {
+    let dir = directories::BaseDirs::new()
+        .expect("get base dirs")
+        .config_dir()
+        .join("systemd/user");
+    let _ = std::process::Command::new("systemctl")
+        .args(["--user", "disable", "--now", "xrenew.timer"])
+        .status();
+    let _ = std::process::Command::new("systemctl")
+        .args(["--user", "stop", "xrenew.timer"])
+        .status();
+    std::fs::remove_file(dir.join("xrenew.service")).ok();
+    std::fs::remove_file(dir.join("xrenew.timer")).ok();
+    println!("Automatic extension disabled");
+}
+
+pub fn should_run() -> bool {
+    if let Some((ts, _)) = crate::logger::read_logs()
+        .iter()
+        .rev()
+        .find(|(_, m)| m.starts_with("SUCCESS"))
+    {
+        let diff = chrono::Local::now() - *ts;
+        diff.num_hours() >= 23
+    } else {
+        true
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,54 @@
+pub async fn update(auto: bool) {
+    let current = semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
+    let client = reqwest::Client::new();
+    let res = client
+        .get("https://api.github.com/repos/h-sumiya/xserver-auto-renew-rs/releases/latest")
+        .header(reqwest::header::USER_AGENT, "xrenew")
+        .send()
+        .await;
+    let Ok(resp) = res else {
+        if !auto {
+            eprintln!("Failed to check latest version");
+        }
+        return;
+    };
+    let json: serde_json::Value = match resp.json().await {
+        Ok(j) => j,
+        Err(e) => {
+            if !auto {
+                eprintln!("Failed to parse version info: {}", e);
+            }
+            return;
+        }
+    };
+    let tag = json.get("tag_name").and_then(|v| v.as_str());
+    let Some(tag) = tag else {
+        return;
+    };
+    let latest_str = tag.trim_start_matches('v');
+    let Ok(latest) = semver::Version::parse(latest_str) else {
+        return;
+    };
+    if latest > current {
+        if !auto {
+            println!("Updating from {} to {}", current, latest);
+        }
+        let cmd = format!(
+            "curl -sSf https://raw.githubusercontent.com/h-sumiya/xserver-auto-renew-rs/main/install.sh | VERSION={} bash",
+            tag
+        );
+        let status = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(cmd)
+            .status();
+        if status.map(|s| s.success()).unwrap_or(false) {
+            if !auto {
+                println!("Update complete");
+            }
+        } else if !auto {
+            eprintln!("Update failed");
+        }
+    } else if !auto {
+        println!("xrenew is up to date ({}).", current);
+    }
+}


### PR DESCRIPTION
## Summary
- break out command-line definition into `cli.rs`
- move update logic to `update.rs`
- move status and webhook helpers to `ops.rs`
- move timer helpers to `task.rs`
- adjust `main.rs` to use the new modules

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_687637ccf34c832c8b4c042d1b087b29