### PR TITLE
Randomize timer start time

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -1,4 +1,5 @@
 use crate::data::value::get_account;
+use rand::Rng;
 
 pub fn enable_auto() {
     {
@@ -11,7 +12,13 @@ pub fn enable_auto() {
     let exe = std::env::current_exe().expect("get exe path");
     let service = include_str!("../systemd/xrenew.service")
         .replace("{{EXEC_PATH}}", exe.to_str().expect("exe path to str"));
-    let timer = include_str!("../systemd/xrenew.timer");
+
+    let mut rng = rand::rng();
+    let hour: u8 = rng.random_range(0..12);
+    let minute: u8 = rng.random_range(0..60);
+    let timer = include_str!("../systemd/xrenew.timer")
+        .replace("{{HOUR}}", &format!("{:02}", hour))
+        .replace("{{MINUTE}}", &format!("{:02}", minute));
     let dir = directories::BaseDirs::new()
         .expect("get base dirs")
         .config_dir()

--- a/systemd/xrenew.timer
+++ b/systemd/xrenew.timer
@@ -2,7 +2,7 @@
 Description=Xserver VPS auto extension timer
 
 [Timer]
-OnCalendar=*-*-* 00/12:10:00
+OnCalendar=*-*-* {{HOUR}}/12:{{MINUTE}}:00
 Persistent=true
 
 [Install]


### PR DESCRIPTION
## Summary
- add placeholders to `xrenew.timer`
- generate a random timer schedule in `enable_auto`

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68768e2b8af8832ca80d228ff70c5c37