### PR TITLE
Add auto refresh command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,5 +37,8 @@ rm -rf "$tmpdir"
 
 hash -r 2>/dev/null || true
 
+# reload systemd timer if configured
+xrenew refresh || true
+
 printf "${GREEN}${BOLD}xrenew installed!${RESET}\n"
 echo -e "まず ${BOLD}xrenew login${RESET}\n次に ${BOLD}xrenew enable${RESET} を実行してください。"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,4 +33,6 @@ pub enum Commands {
         #[arg(long)]
         auto: bool,
     },
+    /// Reload automatic extension timer
+    Refresh,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ mod task;
 mod update;
 
 use ops::{clear_data, set_webhook, show_status};
-use task::{disable_auto, enable_auto, should_run};
+use task::{disable_auto, enable_auto, refresh_auto, should_run};
 use update::update;
 
 #[derive(Debug)]
@@ -48,8 +48,10 @@ impl std::error::Error for ExtendError {}
 
 #[tokio::main]
 async fn main() {
-    initialize_db();
     let cli = Cli::parse();
+    if !matches!(cli.command, Commands::Refresh) {
+        initialize_db();
+    }
     match cli.command {
         Commands::Login => login_flow().await,
         Commands::Extend { auto } => extend_flow(auto).await,
@@ -62,6 +64,7 @@ async fn main() {
         Commands::Clear => clear_data(),
         Commands::Webhook { url } => set_webhook(&url),
         Commands::Update { auto } => update(auto).await,
+        Commands::Refresh => refresh_auto(),
     }
 }
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -51,6 +51,21 @@ pub fn disable_auto() {
     println!("Automatic extension disabled");
 }
 
+pub fn refresh_auto() {
+    let enabled = std::process::Command::new("systemctl")
+        .args(["--user", "is-enabled", "xrenew.timer"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if enabled {
+        disable_auto();
+        enable_auto();
+        println!("Automatic extension refreshed");
+    } else {
+        println!("Automatic extension not configured");
+    }
+}
+
 pub fn should_run() -> bool {
     if let Some((ts, _)) = crate::logger::read_logs()
         .iter()


### PR DESCRIPTION
## Summary
- add `Refresh` command for reloading systemd timer
- call the refresh command from the installer
- avoid DB initialization when running `Refresh`

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_687691ef9f9c832c902bf6c251b7ea28