### PR TITLE
Add 2Captcha key command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ xrenew login
 > [\!IMPORTANT]
 > 初回ログイン時には **二段階認証** を求められる場合があります。必ずこの`login`コマンドを最初に実行し、認証を済ませてください。
 
-### 2\. 自動延長の有効化
+### 2\. (オプション) TwoCaptcha API キーの設定
+
+Cloudflare の Turnstile チャレンジを自動解決したい場合は、TwoCaptcha の API キーを設定します。
+
+```bash
+xrenew captcha <YOUR_API_KEY>
+```
+
+### 3\. 自動延長の有効化
 
 次に、`enable` コマンドを実行して、契約の自動延長を有効化します。これにより、12 時間ごとに自動で延長処理が実行されるようになります。
 
@@ -56,7 +64,7 @@ xrenew login
 xrenew enable
 ```
 
-### 3\. (オプション) Discord 通知設定
+### 4\. (オプション) Discord 通知設定
 
 更新結果を Discord で受け取りたい場合は、以下のコマンドで Webhook URL を設定してください。
 
@@ -75,6 +83,7 @@ xrenew webhook <YOUR_DISCORD_WEBHOOK_URL>
 | `xrenew enable`        | systemd タイマーを登録し、契約の自動延長を有効化します。                 |
 | `xrenew disable`       | 自動延長のタイマーを無効化します。                                       |
 | `xrenew status`        | アカウント情報、Webhook 設定、タイマーの状態、実行ログなどを表示します。 |
+| `xrenew captcha <KEY>` | TwoCaptcha の API キーを設定します。 |
 | `xrenew webhook <URL>` | 実行結果を通知する Discord Webhook URL を設定・更新します。              |
 | `xrenew update`        | `xrenew`を最新バージョンにアップデートします。                           |
 | `xrenew clear`         | 保存されているアカウント情報やログなど、すべてのデータを削除します。     |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,8 @@ pub enum Commands {
     Disable,
     /// Delete saved data
     Clear,
+    /// Set TwoCaptcha API key
+    Captcha { key: String },
     /// Set Discord webhook URL
     Webhook { url: String },
     /// Update xrenew to the latest version

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     data::{
         initialize_db,
-        value::{get_account, set_account},
+        value::{get_account, get_two_captcha_key, set_account},
     },
     external::{send_webhook, two_captcha_solve},
 };
@@ -26,7 +26,7 @@ mod ops;
 mod task;
 mod update;
 
-use ops::{clear_data, set_webhook, show_status};
+use ops::{clear_data, set_two_captcha_key, set_webhook, show_status};
 use task::{disable_auto, enable_auto, refresh_auto, should_run};
 use update::update;
 
@@ -62,6 +62,7 @@ async fn main() {
         Commands::Enable => enable_auto(),
         Commands::Disable => disable_auto(),
         Commands::Clear => clear_data(),
+        Commands::Captcha { key } => set_two_captcha_key(&key),
         Commands::Webhook { url } => set_webhook(&url),
         Commands::Update { auto } => update(auto).await,
         Commands::Refresh => refresh_auto(),
@@ -87,6 +88,15 @@ async fn login_flow() {
                 let password = buf.trim().to_string();
                 let acc = Account { email, password };
                 set_account(&acc);
+                if get_two_captcha_key().is_none() {
+                    buf.clear();
+                    println!("Please enter your TwoCaptcha API key:");
+                    std::io::stdin().read_line(&mut buf).unwrap();
+                    let key = buf.trim().to_string();
+                    if !key.is_empty() {
+                        set_two_captcha_key(&key);
+                    }
+                }
             }
         } else {
             let mut buf = String::new();
@@ -99,6 +109,15 @@ async fn login_flow() {
             let password = buf.trim().to_string();
             let acc = Account { email, password };
             set_account(&acc);
+            if get_two_captcha_key().is_none() {
+                buf.clear();
+                println!("Please enter your TwoCaptcha API key:");
+                std::io::stdin().read_line(&mut buf).unwrap();
+                let key = buf.trim().to_string();
+                if !key.is_empty() {
+                    set_two_captcha_key(&key);
+                }
+            }
         }
     }
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -42,3 +42,8 @@ pub fn set_webhook(url: &String) {
     data::value::set_webhook(url);
     println!("Webhook set");
 }
+
+pub fn set_two_captcha_key(key: &String) {
+    data::value::set_two_captcha_key(key);
+    println!("TwoCaptcha API key set");
+}


### PR DESCRIPTION
## Summary
- add `captcha` subcommand to set 2Captcha API key
- prompt for API key during login if none is stored
- expose helper in ops to store API key
- document new command and setup in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687b549f6580832cac9c87d116cb158f